### PR TITLE
Demo/add plugin actions to context menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ pickle-email-*.html
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 
+# Ignore Visual Studio Code files
+/.vscode
+
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
 

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -15,13 +15,14 @@ import { WorkPackageResource } from "core-app/features/hal/resources/work-packag
     case (kittenAction as WorkPackageAction).key:
       kittenActionHandler(this.getSelectedWorkPackages());
       break;
+
+  icons are located in /vendor/openproject-icon-font/src/icon.svg
+  if no icon is defined, then the key name is used to match an icon.
 */
 
 type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;
 
-// TODO handle not logged in
-// icons are located in /vendor/openproject-icon-font/src/icon.svg
-// if no icon is defined, then the key name is used to match an icon.
+// TODO? menu item is shown when not logged in. should be hidden?
 export const kittenAction: WorkPackageAction = {
   text: "Create Kittens",
   key: "createkittens",

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -2,14 +2,19 @@ import { WorkPackageAction } from "core-app/features/work-packages/components/wp
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 
 /*  
-  USAGE: import kittenAction into OpenProject core in thw wp-context-menu-directive file
-  in the buildItems function edit the following line to include the plugins actions
+  USAGE: import kittenAction, kittenActionHandler into OpenProject core in the wp-context-menu-directive file
+  
+  Step 1: in the buildItems function edit the following line to include the plugins actions
   
   const items = this.permittedActions.map((action:WorkPackageAction) => ({
-  
   to
-
   const items = this.permittedActions.concat([kittenAction]).map((action:WorkPackageAction) => ({
+
+  Step 2: in the triggerContextMenuAction function add a case for the kitten action
+
+    case (kittenAction as WorkPackageAction).key:
+      kittenActionHandler(this.getSelectedWorkPackages());
+      break;
 */
 
 type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -1,22 +1,31 @@
-import {
-  WorkPackageAction,
-} from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import { WorkPackageAction } from "core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service";
+import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 
-const action:WorkPackageAction = {
-    text: 'Create Kittens',
-    key: 'newactionkey',
-    link: '/angular_kittens',
-}
+/*  
+  USAGE: import kittenAction into OpenProject core in thw wp-context-menu-directive file
+  in the buildItems function edit the following line to include the plugins actions
+  
+  const items = this.permittedActions.map((action:WorkPackageAction) => ({
+  
+  to
 
-export const menuItem = {
-  class: undefined as string|undefined,
-  disabled: false,
-  linkText: action.text,
-  href: action.href,
-  icon: action.icon != null ? action.icon : `icon-${action.key}`,
-  onClick: (_:JQuery.TriggeredEvent) => {
-    // do something
-    window.location.href=action.link!
-    return true;
-  },
-}
+  const items = this.permittedActions.concat([kittenAction]).map((action:WorkPackageAction) => ({
+*/
+
+type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;
+
+// TODO handle not logged in
+// icons are located in /vendor/openproject-icon-font/src/icon.svg
+// if no icon is defined, then the key name is used to match an icon.
+export const kittenAction: WorkPackageAction = {
+  text: "Create Kittens",
+  key: "createkittens",
+  link: "/angular_kittens",
+  href: undefined,
+  icon: 'icon-info1',
+  indexBy: undefined,
+};
+
+export const kittenActionHandler: WorkPackagesHandler = (workPackages: WorkPackageResource[]) => {
+  window.location.href = kittenAction.link + '?ids=' + workPackages.map(wp => wp.id).join(',');
+};

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -1,0 +1,22 @@
+import {
+  WorkPackageAction,
+} from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+
+const action:WorkPackageAction = {
+    text: 'Create Kittens',
+    key: 'newactionkey',
+    link: '/angular_kittens',
+}
+
+export const menuItem = {
+  class: undefined as string|undefined,
+  disabled: false,
+  linkText: action.text,
+  href: action.href,
+  icon: action.icon != null ? action.icon : `icon-${action.key}`,
+  onClick: (_:JQuery.TriggeredEvent) => {
+    // do something
+    window.location.href=action.link!
+    return true;
+  },
+}

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -13,7 +13,7 @@ import { WorkPackageResource } from "core-app/features/hal/resources/work-packag
   Step 2: in the triggerContextMenuAction function add a case for the kitten action
 
     case (kittenAction as WorkPackageAction).key:
-      kittenActionHandler(this.getSelectedWorkPackages());
+      kittenActionHandler(this.WorkPackageContextMenuHelper.getBulkActionLink(kittenAction, this.getSelectedWorkPackages()));
       break;
 
   icons are located in /vendor/openproject-icon-font/src/icon.svg
@@ -26,12 +26,10 @@ type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;
 export const kittenAction: WorkPackageAction = {
   text: "Create Kittens",
   key: "createkittens",
-  link: "/angular_kittens",
-  href: undefined,
+  href: "/angular_kittens",
   icon: 'icon-info1',
-  indexBy: undefined,
 };
 
-export const kittenActionHandler: WorkPackagesHandler = (workPackages: WorkPackageResource[]) => {
-  window.location.href = kittenAction.link + '?ids=' + workPackages.map(wp => wp.id).join(',');
+export const kittenActionHandler = (link: string) => {
+  window.location.href = link;
 };


### PR DESCRIPTION
This MR adds a `kittensAction` and `kittensActioHandler` in the context-menu.ts 

Check the usage comment in that file to connect this demo to the open project core.

https://user-images.githubusercontent.com/27402378/142383834-b962fda4-3931-4ef6-9616-7b88f0abdd9a.mp4



