### PR TITLE
Add an example of a context menu for work packages

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1,3 +1,4 @@
 en:
   js:
     proto_plugin_name: 'Kitten plugin'
+    button_create_kittens: 'Create Kittens'

--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -57,7 +57,7 @@ export function initializeProtoPlugin(injector:Injector) {
         const index = _.findIndex(actions, { link: 'logTime' });
         return index !== -1 ? index + 1 : actions.length;
       },
-      text: I18n.t('js.button_create_kittens_table'),
+      text: I18n.t('js.button_create_kittens'),
     }));
   });
 
@@ -74,6 +74,7 @@ export function initializeProtoPlugin(injector:Injector) {
     });
   };
 }
+
 
 @NgModule({
   imports: [

--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -44,8 +44,23 @@ import './global_scripts'
 import {KITTEN_ROUTES} from 'core-app/features/plugins/linked/openproject-proto_plugin/kitten.routes';
 import {UIRouterModule} from '@uirouter/angular';
 import {KittenPageComponent} from 'core-app/features/plugins/linked/openproject-proto_plugin/kitten-page/kitten-page.component';
+import { OpenProjectPluginContext } from '../../plugin-context';
 
 export function initializeProtoPlugin(injector:Injector) {
+  window.OpenProject.getPluginContext().then((pluginContext:OpenProjectPluginContext) => {
+
+    pluginContext.hooks.workPackageTableContextMenu((params:any) => ({
+      key: 'create_kittens',
+      icon: 'icon-projects',
+      link: 'createKittens',
+      indexBy(actions:any) {
+        const index = _.findIndex(actions, { link: 'logTime' });
+        return index !== -1 ? index + 1 : actions.length;
+      },
+      text: I18n.t('js.button_create_kittens_table'),
+    }));
+  });
+
   return () => {
     const hookService = injector.get(HookService);
 

--- a/lib/open_project/proto_plugin/engine.rb
+++ b/lib/open_project/proto_plugin/engine.rb
@@ -49,6 +49,21 @@ module OpenProject::ProtoPlugin
            caption: "Kittens Frontend"
     end
 
+    extend_api_response(:v3, :work_packages, :work_package) do
+      include Redmine::I18n
+
+      # To understand how plugins are created check https://github.com/opf/openproject/blob/dev/frontend/doc/PLUGINS.md
+      link :createKittens do
+        next unless represented.persisted?
+
+        {
+          href: angular_kittens_path,
+          type: 'text/html',
+          title: "Create kitten for #{represented.subject}"
+        }
+      end
+    end
+
     initializer 'proto_plugin.register_hooks' do
       require 'open_project/proto_plugin/hooks'
     end


### PR DESCRIPTION
To add a context menu entry for single work packages, the frontend part
of the plugin must register its context menu as outlined on `main.ts`

The menu entry depends on the `link` property that is defined on the backend
on `engine.rb`.

On the backend part, we can skip creating a link property in specific
applications. Eg. The user not being allowed to see the context menu.

The URL for the plugin is defined on the backend part, `engine.rb`.

It's currently not possible to add context menu entries for multiple
selection of work packages.

_Create Kittens_ plugin:

<img width="1420" alt="Screenshot 2021-11-22 at 11 43 28" src="https://user-images.githubusercontent.com/17965508/142847669-faffc061-91bc-4a9b-9680-2aa7f0f07777.png">


