### PR TITLE
Add an example of a multi selection context menu for work packages

### DIFF
--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -59,6 +59,15 @@ export function initializeProtoPlugin(injector:Injector) {
       },
       text: I18n.t('js.button_create_kittens'),
     }));
+
+    pluginContext.hooks.workPackageBulkContextMenu((params:any) => ({
+      key: 'create_kittens',
+      icon: 'icon-projects',
+      link: 'createKittens',
+      href: '/angular_kittens',
+      text: I18n.t('js.button_create_kittens'),
+    }));
+
   });
 
   return () => {


### PR DESCRIPTION
This PR extends the proto plugin adding an example of an implementation of a 
multi-selection (bulk actions) context menu to the work packages. 

![Kapture 2021-11-23 at 11 16 46](https://user-images.githubusercontent.com/17965508/143006672-4d478c19-4737-484e-b879-af20b1fe9393.gif)


